### PR TITLE
feature/job-restart-stanza

### DIFF
--- a/project-brian.nomad
+++ b/project-brian.nomad
@@ -25,6 +25,13 @@ job "project-brian" {
       value     = "publishing.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "project-brian" {
       driver = "docker"
 


### PR DESCRIPTION
### What

Add restart stanza to job plan. Once upgraded to Nomad 0.8.4 we can control how our jobs our restarted.

### How to review

Check the plan is valid with Nomad 0.8+ and looks OK.

### Who can review

Not me.
