### PR TITLE
allow PORT to be configured from environment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=8008,server=y,suspend=n"
-export PORT="8083"
+export PORT="${PORT:-8083}"
 
 # Restolino configuration
 export RESTOLINO_STATIC="src/main/resources/files"


### PR DESCRIPTION
### What

Change the `export` in `run.sh` so `PORT` can be passed in from the environment

### How to review

* Run brian and set a port number, e.g. `PORT=9876 ./run.sh`
* Check the `Resolved configuration` log output for `port: 9876`

### Who can review

Anyone except @ian-kent
