### PR TITLE
fix mvn build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             </snapshots>
             <id>central</id>
             <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <!--Jitpack io allows us include projects and libraries available on github but not built and published to maven central-->
         <!-- It is used for including internal project modules. See more on https://jitpack.io/-->


### PR DESCRIPTION
Fix for failing maven builds.

https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required
