### PR TITLE
Upgrade jetty dependencies to resolve vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>9.4.39.v20210325</jetty.version>
     </properties>
 
     <repositories>
@@ -72,11 +73,23 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Override vulnerable Jetty dependencies used by restolino -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
         <!-- Restolino Stuff -->
         <dependency>
-            <groupId>com.github.davidcarboni</groupId>
+            <groupId>com.github.onsdigital</groupId>
             <artifactId>restolino</artifactId>
-            <version>0.1.8</version>
+            <version>restolino-0.1.8</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -113,11 +126,6 @@
             <artifactId>commons-fileupload</artifactId>
             <version>1.3.1</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.davidcarboni</groupId>
-            <artifactId>encrypted-file-upload</artifactId>
-            <version>1.0.0</version>
-        </dependency>
 
         <!-- ONS Content Library, fetched through jitpack.io -->
         <dependency>
@@ -143,6 +151,7 @@
 
             <!-- An assembly that includes all dependencies for deployment: -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>
@@ -216,17 +225,6 @@
                             <groupId>org.apache.poi</groupId>
                             <artifactId>poi</artifactId>
                             <version>3.10.1</version>
-                        </exlude>
-                        <!-- The follow two exclusions is covered by trello card: https://trello.com/c/PLIl0hfu -->
-                        <exlude>
-                            <groupId>org.eclipse.jetty</groupId>
-                            <artifactId>jetty-http</artifactId>
-                            <version>9.3.0.M2</version>
-                        </exlude>
-                        <exlude>
-                            <groupId>org.eclipse.jetty</groupId>
-                            <artifactId>jetty-server</artifactId>
-                            <version>9.3.0.M2</version>
                         </exlude>
                         <!-- The follow exclusion is covered by trello card: https://trello.com/c/qvJGv7aX -->
                         <exlude>


### PR DESCRIPTION
### What

- Upgraded `jetty-server` and `jetty-security` (and indirectly `jetty-http`) to resolve vulnerability.
- Removed duplicated dependency and clean up pom
- Switched to ons version of restolino instead of third-party version

### How to review

Ensure tests pass and services runs.
If you would like to test, you will need to upload a CSDB file via florence, eg. I used [this one](https://develop.onsdigital.co.uk/peoplepopulationandcommunity/leisureandtourism/datasets/internationalpassengersurveytimeseriesspreadsheet)

### Who can review

Describe who worked on the changes, so that other people can review.
