### PR TITLE
Add error response body to CSDB/CSV endpoint

### DIFF
--- a/src/main/java/com/github/onsdigital/brian/api/Services.java
+++ b/src/main/java/com/github/onsdigital/brian/api/Services.java
@@ -4,6 +4,7 @@ import com.github.davidcarboni.cryptolite.Crypto;
 import com.github.davidcarboni.cryptolite.Keys;
 import com.github.davidcarboni.encryptedfileupload.EncryptedFileItemFactory;
 import com.github.davidcarboni.restolino.framework.Api;
+import com.github.onsdigital.brian.data.ErrorResponse;
 import com.github.onsdigital.brian.data.TimeSeriesDataSet;
 import com.github.onsdigital.brian.data.TimeSeriesObject;
 import com.github.onsdigital.brian.exception.BrianException;
@@ -40,7 +41,7 @@ import static com.github.onsdigital.logging.v2.event.SimpleEvent.info;
 public class Services {
 
     @POST
-    public List<TimeSeries> postToServices(HttpServletRequest request,
+    public Object postToServices(HttpServletRequest request,
                                            HttpServletResponse response) throws IOException, FileUploadException {
 
         info().log("service endpoint: request received");
@@ -61,13 +62,17 @@ public class Services {
             } else {
                 info().log("returning 400 BAD_REQUEST");
                 response.setStatus(HttpStatus.BAD_REQUEST_400);
-                return null;
+                return new ErrorResponse(HttpStatus.BAD_REQUEST_400,"invalid endpoint called");
             }
 
         } catch (BrianException e) {
             error().logException(e, "failed to convert time series file");
             response.setStatus(e.getHttpStatus());
-            return null;
+            return new ErrorResponse(e);
+        } catch (Exception e) {
+            error().logException(e, "internal server error");
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);
+            return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR_500,"internal server error");
         }
     }
 

--- a/src/main/java/com/github/onsdigital/brian/api/Services.java
+++ b/src/main/java/com/github/onsdigital/brian/api/Services.java
@@ -68,7 +68,7 @@ public class Services {
         } catch (BrianException e) {
             error().logException(e, "failed to convert time series file");
             response.setStatus(e.getHttpStatus());
-            return new ErrorResponse(e);
+            return new ErrorResponse(e.getHttpStatus(),e.getMessage());
         } catch (Exception e) {
             error().logException(e, "internal server error");
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR_500);

--- a/src/main/java/com/github/onsdigital/brian/data/ErrorResponse.java
+++ b/src/main/java/com/github/onsdigital/brian/data/ErrorResponse.java
@@ -1,0 +1,37 @@
+package com.github.onsdigital.brian.data;
+
+import com.github.onsdigital.brian.exception.BrianException;
+
+/**
+ * Data Tranfer Object representing the body of an error response
+ */
+public class ErrorResponse {
+    private int code;
+    private String description;
+
+    public ErrorResponse(int code, String description) {
+        setCode(code);
+        setDescription(description);
+    }
+
+    public ErrorResponse(BrianException be) {
+        this(be.getHttpStatus(),be.getMessage());
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/github/onsdigital/brian/data/ErrorResponse.java
+++ b/src/main/java/com/github/onsdigital/brian/data/ErrorResponse.java
@@ -1,7 +1,5 @@
 package com.github.onsdigital.brian.data;
 
-import com.github.onsdigital.brian.exception.BrianException;
-
 /**
  * Data Tranfer Object representing the body of an error response
  */
@@ -12,10 +10,6 @@ public class ErrorResponse {
     public ErrorResponse(int code, String description) {
         setCode(code);
         setDescription(description);
-    }
-
-    public ErrorResponse(BrianException be) {
-        this(be.getHttpStatus(),be.getMessage());
     }
 
     public int getCode() {


### PR DESCRIPTION
### What

Added an error response body for the CSDB/CSV endpoint.  

Body is similar to other dp apis such asv [dp-areas-api](https://github.com/ONSdigital/dp-areas-api/blob/950b13a0b1ee2bca70926785003f96e43e44e493/models/errors.go#L10), [dp-permissions-api](https://github.com/ONSdigital/dp-permissions-api/blob/7920f1c95abf16be3e0bb8d35b742fad0af5d69d/models/errors.go#L10), [dp-upload-service](https://github.com/ONSdigital/dp-upload-service/blob/78a6ece56bc85823e938e7bb6c66826512f5044e/api/errors.go#L11) or [dp-files-api](https://github.com/ONSdigital/dp-files-api/blob/c63915e4e04da07eb4fd6dcac0a63eb8eb9b203c/api/errors.go#L14)

Eg. 
```json
{
  "code": 400,
  "description": "unexpected characters in csdb data point"
}
```

### How to review

Run it, chuck some files through (see README for instructions on how, there's some valid and invalid examples in `src/test/resources`). Ensure tests pass etc.

### Who can review

Anyone but me.