### PR TITLE
Release 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM onsdigital/java-component
+FROM eclipse-temurin:8-jre
 
 # Add the build artifacts
 WORKDIR /usr/src

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM eclipse-temurin:8-jre
 
 WORKDIR /usr/src
 

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,6 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-java
+    tag: 3.8.8-eclipse-temurin-8
 
 inputs:
   - name: project-brian

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,6 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-java
+    tag: 3.8.8-eclipse-temurin-8
 
 inputs:
   - name: project-brian

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,6 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-java
+    tag: 3.8.8-eclipse-temurin-8
 
 inputs:
   - name: project-brian

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.github.onsdigital</groupId>
             <artifactId>restolino</artifactId>
-            <version>0.7.1</version>
+            <version>0.8.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
### What

Release branch containing…

- [Use temurin container image instead of openJDK](https://github.com/ONSdigital/project-brian/commit/a57f19b3ea48494181696b3ae2555fdc62d28dec)
- [Upgrade restolino to fix jetty vulnerability](https://github.com/ONSdigital/project-brian/commit/a08f70ec707e428cd57a6d8c9a98b2498f45b146)

### How to review

Ensure only expected commits and tests pass

### Who can review

Anyone